### PR TITLE
docs and slight alerting fix

### DIFF
--- a/README
+++ b/README
@@ -5,10 +5,13 @@ run with ./listen_echo
 
 make sure you have stupid_echo as executable.
 follow results echoed out to the 'foobar' file.
+the stupid_echo script exists ONLY to dump the alert out into your preferred format.  I've provided to files for testing, alert1.json -- a set of firing alerts, and alert-fixed.json.   The second file is a another set of alerts, marked as "recovering".   This should allow you to test out your replacement hookscript.
 
 send data with:
 
-curl -XPOST http://localhost:7890/alerts -d@./alerts1.json
+curl -XPOST http://localhost:7890/alerts -d@./alert1.json
+and
+curl -XPOST http://localhost:7890/alerts -d@./alert-fixed.json
 
 in prometheus alertmanager, configure it thusly:
 

--- a/alert-fixed.json
+++ b/alert-fixed.json
@@ -1,0 +1,30 @@
+{
+  "version": "4",
+  "groupKey": "{}:{alertname=\"dumb\", cluster=\"someclustername\"}",
+  "status": "recovery",
+  "receiver": "receiver",
+  "groupLabels": { "foo": "groupLabels" },
+  "commonLabels": { "bar": "commonLabels" },
+  "commonAnnotations": { "baz": "commonAnnotation" },
+  "externalURL": "http://www.angelar.com",
+  "alerts": [
+    {
+      "labels": { "name": "alert0label" },
+      "annotations": { "summary": "summary 0 dude", "description": "big trouble" },
+      "startsAt": "2002-10-02T10:00:00-05:00",
+      "endsAt": "2002-10-02T10:00:00-05:00"
+    },
+    {
+      "labels": { "name": "alert1label" },
+      "annotations": { "summary": "summary 1 dude", "description": "bigger trouble" },
+      "startsAt": "2003-10-02T10:00:00-05:00",
+      "endsAt": "2003-10-02T10:00:00-05:00"
+    },
+    {
+      "labels": { "name": "alert2label" },
+      "annotations": { "summary": "summary 2 dude", "description": "biggest trouble" },
+      "startsAt": "2004-10-02T10:00:00-05:00",
+      "endsAt": "2004-10-02T10:00:00-05:00"
+    }
+  ]
+}

--- a/listen_echo.go
+++ b/listen_echo.go
@@ -45,7 +45,7 @@ type(
 func main() {
   fmt.Println("About to listen on " + LISTENER)
 
-  http.HandleFunc("/alerts", postHandler)  
+  http.HandleFunc("/alerts", postHandler)
   log.Fatal(http.ListenAndServe(LISTENER,nil))
 }
 
@@ -61,6 +61,13 @@ func postHandler(w http.ResponseWriter, r *http.Request) {
     return
   }
 
+  // because alerts are generally sent when firing or recovering
+  // we'll need to get that status first to see how our message
+  // should be prefaced
+
+  status := m.Status
+  // remember, we stuck our hookmessage into a variable named 'm'
+
   for _, element := range(m.Alerts) {
   //we need to break the map into key/val pairs, and then
   // check to see if we have summary/description
@@ -68,7 +75,9 @@ func postHandler(w http.ResponseWriter, r *http.Request) {
     description := element.Annotations["description"]
 
     cmd := "./stupid_echo"  //i made a shell script called stupid_echo also in this repo
-    args := []string{summary, ":", description}
+    // you can put ANY shellscript or app in here, and it will get called
+    // with a list of all the arguments
+    args := []string{status, ":", summary, ":", description}
     if err := exec.Command(cmd, args...).Run(); err != nil{
       fmt.Fprintln(os.Stderr,err)
       os.Exit(1)


### PR DESCRIPTION
* now preface alert with status of overall message, so you won't get double-alerted (once when it fires, once when it recovers) with identical messages
* added some more notes into the readme -- it's been a LONG time since i worked on this, and i couldn't remember what the heck i was doing before
* added a second json file of recover'd alerts for testing
* fixed a typo in the readme so you can now copy-pasta the commands to test.